### PR TITLE
feat: implement PR-based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ name: Release
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -24,11 +27,110 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
-  # Create the release
-  release:
-    name: Create Release
+  # Create release PR when commits are pushed to main
+  create-release-pr:
+    name: Create Release PR
     runs-on: ubuntu-latest
     needs: validate
+    if: github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')
+    outputs:
+      should_release: ${{ steps.semantic-release-dry-run.outputs.new_release_published }}
+      version: ${{ steps.semantic-release-dry-run.outputs.new_release_version }}
+      notes: ${{ steps.semantic-release-dry-run.outputs.new_release_notes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.1.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Semantic Release Dry Run
+        id: semantic-release-dry-run
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          semantic_version: 24
+          dry_run: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release Branch and PR
+        if: steps.semantic-release-dry-run.outputs.new_release_published == 'true'
+        run: |
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Create and switch to release branch
+          RELEASE_BRANCH="release/v${{ steps.semantic-release-dry-run.outputs.new_release_version }}"
+          git checkout -b "$RELEASE_BRANCH"
+          
+          # Run semantic release to generate files (without pushing)
+          npx semantic-release --dry-run --no-ci || true
+          
+          # Generate changelog and version file manually
+          echo "${{ steps.semantic-release-dry-run.outputs.new_release_version }}" > VERSION
+          
+          # Update CHANGELOG.md (this will be done by semantic-release when PR is merged)
+          # For now, we'll add a placeholder entry
+          if [ -f CHANGELOG.md ]; then
+            sed -i '1i\# Changelog\n\n## [v${{ steps.semantic-release-dry-run.outputs.new_release_version }}](https://github.com/${{ github.repository }}/compare/v$(cat VERSION)...v${{ steps.semantic-release-dry-run.outputs.new_release_version }}) ($(date +%Y-%m-%d))\n\n${{ steps.semantic-release-dry-run.outputs.new_release_notes }}\n' CHANGELOG.md
+          else
+            echo -e "# Changelog\n\n## [v${{ steps.semantic-release-dry-run.outputs.new_release_version }}] ($(date +%Y-%m-%d))\n\n${{ steps.semantic-release-dry-run.outputs.new_release_notes }}" > CHANGELOG.md
+          fi
+          
+          # Commit changes
+          git add VERSION CHANGELOG.md
+          git commit -m "chore(release): ${{ steps.semantic-release-dry-run.outputs.new_release_version }} [skip ci]"
+          
+          # Push branch
+          git push origin "$RELEASE_BRANCH"
+          
+          # Create PR using GitHub CLI
+          gh pr create \
+            --base main \
+            --head "$RELEASE_BRANCH" \
+            --title "chore(release): v${{ steps.semantic-release-dry-run.outputs.new_release_version }}" \
+            --body "$(cat <<'EOF'
+          ## Release v${{ steps.semantic-release-dry-run.outputs.new_release_version }}
+          
+          This PR contains the release changes for version ${{ steps.semantic-release-dry-run.outputs.new_release_version }}.
+          
+          ### Release Notes
+          ${{ steps.semantic-release-dry-run.outputs.new_release_notes }}
+          
+          ### Files Changed
+          - VERSION: Updated to ${{ steps.semantic-release-dry-run.outputs.new_release_version }}
+          - CHANGELOG.md: Added release notes
+          
+          **Please review and merge this PR to publish the release.**
+          
+          🤖 This PR was automatically created by the release workflow.
+          EOF
+          )" \
+            --reviewer michiosw
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Publish the release after PR is merged
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     outputs:
       released: ${{ steps.semantic-release.outputs.new_release_published }}
       version: ${{ steps.semantic-release.outputs.new_release_version }}
@@ -66,8 +168,8 @@ jobs:
   notify:
     name: Discord Notification
     runs-on: ubuntu-latest
-    needs: release
-    if: needs.release.outputs.released == 'true'
+    needs: publish-release
+    if: needs.publish-release.outputs.released == 'true'
     steps:
       - name: Send Discord Notification
         uses: Ilshidur/action-discord@master
@@ -75,9 +177,9 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
         with:
           args: |
-            🚀 **New Release: v${{ needs.release.outputs.version }}**
+            🚀 **New Release: v${{ needs.publish-release.outputs.version }}**
             
             Repository: **${{ github.repository }}**
-            Release Notes: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.release.outputs.version }}
+            Release Notes: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ needs.publish-release.outputs.version }}
             
-            ${{ needs.release.outputs.notes }}
+            ${{ needs.publish-release.outputs.notes }}


### PR DESCRIPTION
## Summary
- Implement PR-based release workflow to work with branch protection rules
- Creates release PRs automatically when semantic-release detects new versions
- Publishes releases after PR is merged
- Auto-requests review from michiosw

## Changes
- Modified `.github/workflows/release.yml` to use a two-step process:
  1. **Create Release PR**: Runs on push to main, creates PR with release changes
  2. **Publish Release**: Runs when release PR is merged, publishes to GitHub

## How it works
1. Push conventional commits to main → CI creates release PR if version bump needed
2. Review and merge release PR → CI publishes the actual release
3. No bypass rules needed - everything goes through PR review process

## Test Plan
- [x] Branch protection rules remain enforced
- [ ] Test release PR creation (will happen after this PR is merged)
- [ ] Test release publishing (will happen after release PR is merged)

🤖 This PR enables proper release management with branch protection compliance.