### PR TITLE
fix: body of email missing

### DIFF
--- a/packages/mcp-gmail/src/tools.ts
+++ b/packages/mcp-gmail/src/tools.ts
@@ -99,12 +99,18 @@ function createEmailMessage(args: any): string {
   const headers = [
     'From: me',
     `To: ${args.to.join(', ')}`,
-    args.cc ? `Cc: ${args.cc.join(', ')}` : '',
     `Subject: ${args.subject}`,
     'MIME-Version: 1.0',
     'Content-Type: text/plain; charset=UTF-8',
-    '',
-  ].filter(Boolean);
+  ];
+
+  // Add CC header only if CC recipients exist
+  if (args.cc && args.cc.length > 0) {
+    headers.push(`Cc: ${args.cc.join(', ')}`);
+  }
+
+  // Add empty line separator between headers and body
+  headers.push('');
 
   return [...headers, args.body].join('\r\n');
 }


### PR DESCRIPTION
The bug was that `filter(Boolean)` was removing the empty string that serves as the required blank line separator between email headers and body, causing email clients to not parse the body content properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for constructing email headers, resulting in clearer handling of CC recipients and consistent formatting of emails. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->