### PR TITLE
fix: audio continuing after tab close

### DIFF
--- a/apps/electron-app/src/main/browser/application-window.ts
+++ b/apps/electron-app/src/main/browser/application-window.ts
@@ -210,7 +210,7 @@ export class ApplicationWindow extends EventEmitter {
     }
   }
 
-  public destroy(): void {
+  public async destroy(): Promise<void> {
     if (this.window.isDestroyed()) return;
 
     try {
@@ -222,7 +222,7 @@ export class ApplicationWindow extends EventEmitter {
 
     try {
       // Clean up ViewManager
-      this.viewManager.destroy();
+      await this.viewManager.destroy();
     } catch (error) {
       logger.warn("Error destroying ViewManager:", error);
     }

--- a/apps/electron-app/src/main/browser/browser.ts
+++ b/apps/electron-app/src/main/browser/browser.ts
@@ -180,7 +180,7 @@ export class Browser extends EventEmitter {
   /**
    * Destroys the browser and cleans up resources
    */
-  public destroy(): void {
+  public async destroy(): Promise<void> {
     if (this._isDestroyed) return;
 
     logger.debug("🧹 Browser: Starting cleanup process...");
@@ -195,7 +195,7 @@ export class Browser extends EventEmitter {
     for (const [webContentsId, appWindow] of this.applicationWindows) {
       try {
         logger.debug("🧹 Browser: Destroying ApplicationWindow", webContentsId);
-        appWindow.destroy();
+        await appWindow.destroy();
       } catch (error) {
         logger.warn("Error destroying ApplicationWindow:", error);
       }

--- a/apps/electron-app/src/main/browser/tab-manager.ts
+++ b/apps/electron-app/src/main/browser/tab-manager.ts
@@ -216,7 +216,7 @@ export class TabManager extends EventEmitter {
   /**
    * Closes a tab and manages focus
    */
-  public closeTab(tabKey: string): boolean {
+  public async closeTab(tabKey: string): Promise<boolean> {
     if (!this.tabs.has(tabKey)) {
       logger.warn(`Cannot close tab ${tabKey} - not found`);
       return false;
@@ -232,7 +232,7 @@ export class TabManager extends EventEmitter {
       }
     }
 
-    this.removeBrowserView(tabKey);
+    await this.removeBrowserView(tabKey);
     this.tabs.delete(tabKey);
 
     if (wasActive) {
@@ -750,7 +750,7 @@ export class TabManager extends EventEmitter {
     }, TAB_CONFIG.CLEANUP_INTERVAL_MS);
   }
 
-  private performTabMaintenance(): void {
+  private async performTabMaintenance(): Promise<void> {
     this.maintenanceCounter++;
     const now = Date.now();
     const totalTabs = this.tabs.size;
@@ -788,7 +788,7 @@ export class TabManager extends EventEmitter {
         tab.asleep &&
         timeSinceActive > TAB_CONFIG.ARCHIVE_THRESHOLD_MS
       ) {
-        this.closeTab(tabKey);
+        await this.closeTab(tabKey);
       }
     }
   }
@@ -814,10 +814,10 @@ export class TabManager extends EventEmitter {
     viewManager.setViewVisible(tabKey, false);
   }
 
-  private removeBrowserView(tabKey: string): void {
+  private async removeBrowserView(tabKey: string): Promise<void> {
     const viewManager = this.viewManager;
     if (viewManager) {
-      viewManager.removeView(tabKey);
+      await viewManager.removeBrowserView(tabKey);
     }
   }
 

--- a/apps/electron-app/src/main/index.ts
+++ b/apps/electron-app/src/main/index.ts
@@ -228,7 +228,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
 
     // Destroy browser instance (will clean up its own menu)
     if (browser) {
-      browser.destroy();
+      await browser.destroy();
     }
 
     // Close all windows
@@ -699,7 +699,7 @@ app.on("before-quit", async event => {
 
   // Clean up browser resources
   if (browser && !browser.isDestroyed()) {
-    browser.destroy();
+    await browser.destroy();
   }
 
   // Clean up memory monitor

--- a/apps/electron-app/src/main/ipc/browser/tabs.ts
+++ b/apps/electron-app/src/main/ipc/browser/tabs.ts
@@ -72,7 +72,9 @@ ipcMain.handle("tabs:update", async (event, tabKey: string, _updates: any) => {
 
 ipcMain.handle("remove-tab", async (event, tabKey: string) => {
   const appWindow = browser?.getApplicationWindow(event.sender.id);
-  appWindow?.tabManager.closeTab(tabKey);
+  if (appWindow) {
+    await appWindow.tabManager.closeTab(tabKey);
+  }
 });
 
 ipcMain.handle("switch-tab", async (event, tabKey: string) => {

--- a/apps/electron-app/src/main/utils/tab-agent.ts
+++ b/apps/electron-app/src/main/utils/tab-agent.ts
@@ -248,7 +248,7 @@ export async function sendTabToAgent(browser: Browser): Promise<void> {
 
   // Now remove tab from UI (non-blocking for user)
   // Use TabManager to close the tab directly instead of IPC to renderer
-  const closed = tabManager.closeTab(checkKey);
+  const closed = await tabManager.closeTab(checkKey);
   if (closed) {
     logger.info(`Tab ${checkKey} closed successfully`);
   } else {


### PR DESCRIPTION
## Summary
- Stop audio playback immediately when closing browser tabs
- Fix issue where media streams continued playing after tab was closed
- Ensure proper cleanup of web content and media elements

## Test plan
- [x] Open a tab with playing audio/video content
- [x] Close the tab while media is playing
- [x] Verify audio stops immediately upon tab close
- [x] Check that no orphaned audio processes remain
- [x] Test with multiple tabs playing audio simultaneously
- [x] Verify normal tab functionality is not affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of tab and browser window closure, ensuring all resources (including audio and video) are properly cleaned up before shutdown.
  * Enhanced handling of tab removal to prevent errors when closing non-existent tabs.

* **Chores**
  * Updated shutdown and maintenance processes to be asynchronous, ensuring smoother and more predictable app shutdown and resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->