### PR TITLE
fix(build): resolve Node.js module warnings in shared-types

### DIFF
--- a/apps/electron-app/electron.vite.config.ts
+++ b/apps/electron-app/electron.vite.config.ts
@@ -6,7 +6,7 @@ import { sentryVitePlugin } from "@sentry/vite-plugin";
 export default defineConfig({
   main: {
     plugins: [
-      externalizeDepsPlugin({ exclude: ["@modelcontextprotocol/sdk"] }),
+      externalizeDepsPlugin({ exclude: ["@modelcontextprotocol/sdk", "@vibe/shared-types"] }),
       sentryVitePlugin({
         authToken: "some invalid auth token",
         org: "some invalid org",
@@ -27,7 +27,7 @@ export default defineConfig({
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src/main"),
-        "@vibe/shared-types": path.resolve(__dirname, "../../packages/shared-types/src/index.ts"),
+        "@vibe/shared-types": path.resolve(__dirname, "../../packages/shared-types/src"),
       },
     },
     build: {
@@ -44,10 +44,10 @@ export default defineConfig({
     },
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({ exclude: ["@vibe/shared-types"] })],
     resolve: {
       alias: {
-        "@vibe/shared-types": path.resolve(__dirname, "../../packages/shared-types/src/index.ts"),
+        "@vibe/shared-types": path.resolve(__dirname, "../../packages/shared-types/src"),
       },
     },
   },
@@ -55,7 +55,7 @@ export default defineConfig({
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src/renderer/src"),
-        "@vibe/shared-types": path.resolve(__dirname, "../../packages/shared-types/src/index.ts"),
+        "@vibe/shared-types": path.resolve(__dirname, "../../packages/shared-types/src"),
       },
     },
     server: {

--- a/apps/electron-app/src/main/index.ts
+++ b/apps/electron-app/src/main/index.ts
@@ -31,11 +31,8 @@ import {
   isFirstLaunch,
   handleStoreEncryption,
 } from "@/store/desktop-store";
-import {
-  createLogger,
-  MAIN_PROCESS_CONFIG,
-  findFileUpwards,
-} from "@vibe/shared-types";
+import { createLogger, MAIN_PROCESS_CONFIG } from "@vibe/shared-types";
+import { findFileUpwards } from "@vibe/shared-types/utils/path";
 import {
   init,
   browserWindowSessionIntegration,

--- a/apps/electron-app/src/main/processes/mcp-manager-process.ts
+++ b/apps/electron-app/src/main/processes/mcp-manager-process.ts
@@ -10,10 +10,12 @@ import http from "http";
 import {
   getAllMCPServerConfigs,
   type MCPServerConfig,
-  findWorkspaceRoot,
-  getMonorepoPackagePath,
   createLogger,
 } from "@vibe/shared-types";
+import {
+  findWorkspaceRoot,
+  getMonorepoPackagePath,
+} from "@vibe/shared-types/utils/path";
 
 const logger = createLogger("MCPManager");
 

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -23,6 +23,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./utils/path": {
+      "import": "./dist/utils/path.js",
+      "require": "./dist/utils/path.js",
+      "types": "./dist/utils/path.d.ts"
     }
   },
   "files": [

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -27,9 +27,6 @@ export * from "./constants";
 // Utilities
 export * from "./utils";
 
-// Path utilities (Node.js only)
-export * from "./utils/path";
-
 // Logging utilities
 export * from "./logger";
 


### PR DESCRIPTION
## Summary
- Fixes build warnings about Node.js modules being externalized for browser compatibility
- Separates Node.js-only utilities from browser-safe exports
- No runtime changes, only build-time organization

## Changes
- Removed path utilities export from main `shared-types` index
- Added subpath export `./utils/path` for Node.js-only utilities  
- Updated imports in the 2 files that use these utilities
- Updated electron-vite aliases to support subpath imports

## Test plan
- [x] Build completes without warnings
- [x] Path utilities still work in Node.js contexts
- [x] No browser code imports Node.js modules

Fixes #43

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated export path for path utilities in the shared types package, allowing direct imports from a new subpath.
* **Refactor**
  * Updated import statements in the Electron app to use the new subpath for path utilities.
  * Adjusted build configuration to align with the new module resolution for shared types.
* **Chores**
  * Updated package configuration to reflect new export structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->