### PR TITLE
fix: prevent Gmail MCP server orphaned processes on app quit

### DIFF
--- a/apps/electron-app/src/main/index.ts
+++ b/apps/electron-app/src/main/index.ts
@@ -468,8 +468,17 @@ function initializeApp(): boolean {
     memoryMonitor.setBrowserInstance(browser);
   }
 
+  // Use before-quit for better control over shutdown process
+  app.on("before-quit", async event => {
+    if (!isShuttingDown) {
+      event.preventDefault();
+      await gracefulShutdown("before-quit");
+      app.quit(); // Trigger quit again after cleanup
+    }
+  });
+
   app.on("will-quit", event => {
-    // If we're not already shutting down, prevent quit and use graceful shutdown
+    // Only allow quit if shutdown is complete
     if (!isShuttingDown) {
       event.preventDefault();
       gracefulShutdown("will-quit");
@@ -484,6 +493,7 @@ function initializeApp(): boolean {
 
     // Force exit after a timeout if process doesn't exit cleanly
     setTimeout(() => {
+      logger.warn("Force exiting after timeout");
       process.exit(0);
     }, 2000);
   });


### PR DESCRIPTION
## Summary
- Prevents Gmail MCP server from remaining as orphaned process after app quit
- Fixes "port already in use" errors on subsequent app launches
- Ensures clean shutdown of all child processes

## Problem
When quitting the Vibe app in production, the Gmail MCP server process (running on port 3001) was not being properly terminated. This caused "EADDRINUSE" errors on subsequent launches because the port was still occupied by the orphaned process.

The root cause was that the MCP Worker was auto-restarting the Gmail server after the app initiated shutdown, creating a race condition where the server would restart just as the app was quitting.

## Solution
Added an `isShuttingDown` flag to the MCP Worker that prevents auto-restart during app shutdown. This ensures that when the app is quitting, terminated child processes stay terminated.

## Test plan
- [x] Build the app with `pnpm build:mac`
- [x] Install and run from Applications folder
- [x] Configure OpenAI key and Gmail OAuth
- [x] Verify Gmail MCP tools work (ask about latest email)
- [x] Quit the app via menu
- [x] Check that port 3001 is free (no orphaned processes)
- [x] Launch app again and verify Gmail tools still work

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced shutdown procedures for increased reliability and faster termination across the app.
  * Reduced wait times for server and connection shutdowns, resulting in quicker app exits.
  * Improved logging for process lifecycle events, making shutdown and restart behaviors more transparent to users.
  * Increased robustness when terminating background processes, minimizing the chance of lingering or stuck processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->